### PR TITLE
fix(ci): allow chore commits for changesets

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -15,7 +15,7 @@ module.exports = {
     "subject-full-stop": [2, "never", "."],
     "type-case": [2, "always", "lower-case"],
     "type-empty": [2, "never"],
-    "type-enum": [2, "always", ["feat", "bug", "maint"]],
+    "type-enum": [2, "always", ["feat", "bug", "maint", "chore"]],
     "scope-case": [2, "always", "lower-case"],
     "scope-enum": [
       2,


### PR DESCRIPTION
Fixes the release workflow - changesets needs to create `chore:` commits but commitlint was blocking them.

Adds `chore` to allowed commit types in commitlint config.

Related to #28